### PR TITLE
Update the images for language directories

### DIFF
--- a/nl/de/tours.json
+++ b/nl/de/tours.json
@@ -7,14 +7,14 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/de/images/whatsnew/resource-group_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/resource-group_v3.png?lang=de",
         "title": "Einführung von Ressourcengruppen",
         "body": "Mithilfe von anpassbaren Gruppen können Sie Ihre Ressourcen organisieren und schützen.",
         "ctaText": "Weitere Informationen.",
         "ctaURL": "/docs/admin/resourcegroups.html"
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/de/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=de",
         "title": "Zentrale Übersicht",
         "body": "Sie benötigen eine umfassende Übersicht über Ihre gesamten Ressourcen? Über das Dashboard können Sie diese anhand der für Sie relevanten Kriterien filtern.",
         "ctaText": "Weitere Informationen.",
@@ -33,17 +33,17 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/de/images/whatsnew/introducing_cloud_brand.gif",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/introducing_cloud_brand.gif?lang=de",
         "title": "Willkommen bei IBM Cloud",
         "body": "Schön, dass Sie hier sind! Ihr Konto ist eingerichtet; eine Ressourcengruppe, eine Organisation und ein Bereich sind bereits erstellt und Sie können sofort mit der Bearbeitung Ihrer Projekte beginnen."
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/de/images/whatsnew/navigation.gif",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/navigation.gif?lang=de",
         "title": "Was soll erstellt werden?",
         "body": "Ihnen steht eine breite Palette von Services zur Verfügung, die Sie als Bausteine für die Ausführung Ihrer Apps nutzen können. Verwenden Sie das Menüsymbol, um die Navigation zu öffnen und mit der Erkundung von IBM Cloud zu beginnen."
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/de/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=de",
         "title": "Zentrale Übersicht",
         "body": "Sie benötigen eine umfassende Übersicht über Ihre gesamten Ressourcen? Nachdem Sie mit der Erstellung begonnen haben, können Sie über das Dashboard die Daten anhand der für Sie relevanten Kriterien filtern. ",
         "ctaText": "Weitere Informationen.",

--- a/nl/fr/tours.json
+++ b/nl/fr/tours.json
@@ -7,14 +7,14 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/fr/images/whatsnew/resource-group_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/resource-group_v3.png?lang=fr",
         "title": "Présentation des groupes de ressources",
         "body": "Vous pouvez utiliser des groupes personnalisables afin d'organiser et sécuriser vos ressources.",
         "ctaText": "En savoir plus.",
         "ctaURL": "/docs/admin/resourcegroups.html"
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/fr/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=fr",
         "title": "Tout voir au même endroit",
         "body": "Vous souhaitez avoir une vue globale de toutes vos ressources ? Vous pouvez désormais accéder au tableau de bord et effectuer un filtrage pour afficher ce qui compte pour vous.",
         "ctaText": "En savoir plus.",
@@ -33,17 +33,17 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/fr/images/whatsnew/introducing_cloud_brand.gif",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/introducing_cloud_brand.gif?lang=fr",
         "title": "Bienvenue dans IBM Cloud",
         "body": "Maintenant que votre compte est configuré avec un groupe de ressources, une organisation et un espace qui ont été créés pour vous, vous êtes fin prêt pour commencer à travailler sur vos projets."
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/fr/images/whatsnew/navigation.gif",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/navigation.gif?lang=fr",
         "title": "Que souhaitez-vous construire ?",
         "body": "Nous proposons un grand éventail de services que vous pouvez utiliser lors de la construction de blocs pour exécuter vos applications. Utilisez l'icône Menu pour ouvrir la navigation et commencer à explorer IBM Cloud."
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/fr/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=fr",
         "title": "Tout voir au même endroit",
         "body": "Vous souhaitez avoir une vue globale de toutes vos ressources ? Après avoir commencé à construire, vous pouvez désormais accéder au tableau de bord et effectuer un filtrage pour afficher ce qui compte pour vous. ",
         "ctaText": "En savoir plus.",

--- a/nl/ja/tours.json
+++ b/nl/ja/tours.json
@@ -7,14 +7,14 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/ja/images/whatsnew/resource-group_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/resource-group_v3.png?lang=ja",
         "title": "リソース・グループの導入",
         "body": "カスタマイズ可能なグループを使用して、リソースを編成し、保護することができます。",
         "ctaText": "詳細はこちら。",
         "ctaURL": "/docs/admin/resourcegroups.html"
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/ja/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=ja",
         "title": "1 カ所ですべて表示",
         "body": "すべてのリソースのグローバル・ビューをお望みですか? ダッシュボードからすべてのリソースを、お客様にとって重要なものでフィルターに掛けられるようになりました。",
         "ctaText": "詳細はこちら。",
@@ -33,17 +33,17 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/ja/images/whatsnew/introducing_cloud_brand.gif",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/introducing_cloud_brand.gif?lang=ja",
         "title": "IBM Cloud へようこそ",
         "body": "ご利用いただき、ありがとうございます。お客様のアカウントで、お客様用に作成済みのリソース・グループ、組織、スペースのセットアップが完了しました。これで、プロジェクトの作業を開始する準備が整いました。"
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/ja/images/whatsnew/navigation.gif",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/navigation.gif?lang=ja",
         "title": "何を構築しますか?",
         "body": "お客様がアプリを実行するためにビルディング・ブロックとして使用できる、広範なサービスを提供します。メニュー・アイコンを使ってナビゲーションを開き、IBM Cloud の探索を開始してください。"
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/ja/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=ja",
         "title": "1 カ所ですべて表示",
         "body": "すべてのリソースのグローバル・ビューをお望みですか? 構築を開始した後に、ダッシュボードに移動して、お客様にとって重要なものでフィルターに掛けられます。",
         "ctaText": "詳細はこちら。",

--- a/nl/ko/tours.json
+++ b/nl/ko/tours.json
@@ -33,12 +33,12 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/introducing_cloud_brand.gif?lang=ko",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/introducing_cloud_brand.gif?lang=ko",
         "title": "IBM Cloud 시작",
         "body": "여러분을 환영합니다! 이미 여러분을 위해 구축해 놓은 리소스 그룹, 조직 및 영역을 통해 계정이 설정되어 있으며 이제 프로젝트에 대한 작업을 시작할 수 있습니다. "
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/navigation.gif?lang=ko",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/navigation.gif?lang=ko",
         "title": "빌드하려는 것이 무엇입니까? ",
         "body": "IBM은 여러분이 앱을 실행하기 위해 블록을 빌드할 때 사용할 수 있는 다양한 서비스 세트를 제공합니다. 메뉴 아이콘을 사용하여 탐색을 열고 IBM Cloud에 대해 살펴보십시오. "
       },

--- a/nl/ko/tours.json
+++ b/nl/ko/tours.json
@@ -7,14 +7,14 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/resource-group_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/resource-group_v3.png?lang=ko",
         "title": "리소스 그룹 도입",
         "body": "사용자 정의할 수 있는 그룹을 사용하여 리소스를 구성하고 보안할 수 있습니다.",
         "ctaText": "자세히 보기",
         "ctaURL": "/docs/admin/resourcegroups.html"
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=ko",
         "title": "한 곳에서 모두 보기",
         "body": "모든 리소스에 대한 글로벌 보기를 원하십니까? 이제 대시보드로 이동하여 중요한 항목별로 필터링할 수 있습니다.",
         "ctaText": "자세히 보기.",
@@ -33,17 +33,17 @@
     },
     "tourPanels": [
       {
-        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/introducing_cloud_brand.gif",
+        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/introducing_cloud_brand.gif?lang=ko",
         "title": "IBM Cloud 시작",
         "body": "여러분을 환영합니다! 이미 여러분을 위해 구축해 놓은 리소스 그룹, 조직 및 영역을 통해 계정이 설정되어 있으며 이제 프로젝트에 대한 작업을 시작할 수 있습니다. "
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/navigation.gif",
+        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/navigation.gif?lang=ko",
         "title": "빌드하려는 것이 무엇입니까? ",
         "body": "IBM은 여러분이 앱을 실행하기 위해 블록을 빌드할 때 사용할 수 있는 다양한 서비스 세트를 제공합니다. 메뉴 아이콘을 사용하여 탐색을 열고 IBM Cloud에 대해 살펴보십시오. "
       },
       {
-        "image": "/docs/api/content/guided-tours/nl/ko/images/whatsnew/Dashboard_v3.png",
+        "image": "/docs/api/content/guided-tours/images/whatsnew/Dashboard_v3.png?lang=ko",
         "title": "한 곳에서 모두 보기",
         "body": "모든 리소스에 대한 글로벌 보기를 원하십니까? 빌드를 시작하고 나면 대시보드로 이동하여 중요한 항목별로 필터링할 수 있습니다. ",
         "ctaText": "자세히 보기.",


### PR DESCRIPTION
The current image URLs are not reachable. 
This will not fix zh-TW and other hypen languages.  For these directories, even the tour file is not reachable. 
IBM Cloud tour currently uses two character lang in its API calls, ie, zh.
Docs API does support the hyphen either, so these calls will not succeed.  (returns english default)

- https://console.bluemix.net/docs/api/guided-tours?lang=zh
-  https://console.bluemix.net/docs/api/guided-tours?lang=zh-TW
